### PR TITLE
Fix crash when disconnect a bluetooth device

### DIFF
--- a/eqMac2/Source/EQEngine/EQEngine.mm
+++ b/eqMac2/Source/EQEngine/EQEngine.mm
@@ -322,6 +322,9 @@ Float32* EQEngine::GetEqGains(){
     for (int i = 0; i < 32; i++) {
         
         int incrementor = i;
+        if (this == NULL){
+            return NULL;
+        }
         AudioUnit eqUnit = mEqualizerUnit1;
         if (i >= 16) {
             incrementor = i - 16;


### PR DESCRIPTION
### The problem: 
When a bluetooth device disconnects from the mac the EQ crashes due to exc_bad_access error. 

### Understanding it:
On the `EQEngine.mm` class there is a method called `GetEqGains`, that checks the current device attached into the EQ through memory addressing retained  by the `mEqualizerUnit1 `object of `EQEngine.h`.

When a device disconnects from the mac, a method is called to wipe the `Devices` from the list of connected devices in the `EQHost.mm` by the `deleteEQEngine` method. But this method leaves residue in the before mentioned `EQEngine.h` class.

### The solution (kind of)
Check if the EQEngine object is null and do not try to set the eq on the ghost audio device.

It would be nice to return to the last device and all... But this was a very fast fix done to help use this wonderful application without the annoying disconnection crash.