### PR TITLE
Don't set volume to full blast when initialising audio engine!

### DIFF
--- a/eqMac2/Source/EQHost/EQHost.mm
+++ b/eqMac2/Source/EQHost/EQHost.mm
@@ -37,7 +37,7 @@ static NSNumber *bandMode;
     
     NSArray *savedGains = [Storage getSelectedGains];
     [self setEQEngineFrequencyGains: savedGains];
-    [Devices setOutputVolumeForDeviceID:output to: 1]; //full blast
+    [Devices setOutputVolumeForDeviceID:output to: stashedVolume]; //Avoid blowing out people's eardrums by restoring the original volume
 }
 
 


### PR DESCRIPTION
I think this is the bug that is causing the volume to jump to full when people re-inintialise the audio engine. I've not tested this because I don't have the build environment set up, but looking at the reported behaviour and the code I think this is the problem and my guess is that restoring the stashed volume rather than setting it to full volume is the solution