### PR TITLE
Added a delay to processing listener statement on Sample Rate changes

### DIFF
--- a/native/app/Source/Application.swift
+++ b/native/app/Source/Application.swift
@@ -325,10 +325,13 @@ class Application {
         retain: false
       ) {
         //        selectOutput(device: selectedDevice)
-        stopListeners()
-        stopEngines()
-        self.matchDriverSampleRateToOutput()
-        createAudioPipeline()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            // need a delay, because emitter should finish it's work at first
+            stopListeners()
+            stopEngines()
+            self.matchDriverSampleRateToOutput()
+            createAudioPipeline()
+        }
       }
       
       selectedDeviceVolumeChangedListener = AudioDeviceEvents.on(


### PR DESCRIPTION
In the handler it had a call to `createAudioPipeline()` that creates a new re-subscription to the same event, but then cycle by listeners finished and event emitter just cleared all listeners including new one in this code:


    _listeners[targetID] = _listeners[targetID]!.filter({
        if let listener = $0.object {
          if (listener._listening) {
            listener._trigger(data)
            return listener._listening
          }
        }
        return false
      }).nilIfEmpty

