### PR TITLE
fixes #227 - crashes and no sound after device adding and removing

### DIFF
--- a/native/app/Source/Application.swift
+++ b/native/app/Source/Application.swift
@@ -214,14 +214,28 @@ class Application {
       Console.log("listChanged", list)
       
       if list.added.count > 0 {
-        let added = list.added[0]
-        selectOutput(device: added)
+        for added in list.added {
+          if Output.isDeviceAllowed(added) {
+            selectOutput(device: added)
+            break
+          }
+        }
       } else if (list.removed.count > 0) {
-        let removed = list.removed[0]
-        if (removed.id != selectedDevice.id) {
-          stopEngines()
+        
+        var currentDeviceRemoved = false
+        for removed in list.removed {
+          if removed.id == selectedDevice.id {
+            currentDeviceRemoved = true
+            break
+          }
+        }
+        
+        stopEngines()
+        if (!currentDeviceRemoved) {
+          try! AudioDeviceEvents.recreateEventEmitters([.isAliveChanged, .volumeChanged, .nominalSampleRateChanged])
+          self.setupDriverDeviceEvents()
           Utilities.delay(500) {
-            createAudioPipeline()
+              createAudioPipeline()
           }
         }
       }

--- a/native/app/Source/Audio/Outputs/Output.swift
+++ b/native/app/Source/Audio/Outputs/Output.swift
@@ -13,6 +13,10 @@ import EmitterKit
 import AVFoundation
 
 class Output {
+  static func isDeviceAllowed(_ device: AudioDevice) -> Bool {
+    return device.transportType != nil && Constants.SUPPORTED_TRANSPORT_TYPES.contains(device.transportType!) && !device.isInputOnlyDevice()
+  }
+  
   static var allowedDevices: [AudioDevice] {
     return AudioDevice.allOutputDevices()
       .filter({ device in
@@ -21,7 +25,7 @@ class Output {
             return false
           }
         }
-        return device.transportType != nil && Constants.SUPPORTED_TRANSPORT_TYPES.contains(device.transportType!)
+        return isDeviceAllowed(device)
       })
   }
 

--- a/native/app/Source/Extensions/AudioDevice.swift
+++ b/native/app/Source/Extensions/AudioDevice.swift
@@ -61,8 +61,11 @@ extension AudioDevice {
         self.setMute(newValue, channel: 0, direction: .playback)
       } else {
         Console.log(self.channels(direction: .playback).intValue)
-        for channel in 1...self.channels(direction: .playback).intValue {
-          self.setMute(newValue, channel: UInt32(channel), direction: .playback)
+        let channels = self.channels(direction: .playback).intValue
+        if channels >= 1 {
+          for channel in 1...self.channels(direction: .playback).intValue {
+            self.setMute(newValue, channel: UInt32(channel), direction: .playback)
+          }
         }
       }
     }


### PR DESCRIPTION
This is main logic fixes for device switching described in #227.
Tested with all devices that I have on MacOS 10.15.5, works well.

However rarely still happens EXC_BAD_ACCESS, but it seems we will need a lot of work to find it.