### PR TITLE
Updated FAQ with proper uninstall command

### DIFF
--- a/site/src/app/routes/faq/faq.component.ts
+++ b/site/src/app/routes/faq/faq.component.ts
@@ -37,7 +37,7 @@ export class FAQComponent implements OnInit {
     <br>That will run a script to uninstall the app and the driver properly.
     <br>If for whatever reason you cannot run eqMac, to uninstall the driver you can run this command in Terminal: 
     <br><br>
-    <div class="terminal-command">sudo rm -rf /Library/Audio/Plug-Ins/HAL/eqMac.driver/ && launchctl kickstart -k system/com.apple.audio.coreaudiod &>/dev/null</div>`
+    <div class="terminal-command">sudo rm -rf /Library/Audio/Plug-Ins/HAL/eqMac.driver/ && sudo launchctl kickstart -k system/com.apple.audio.coreaudiod &>/dev/null</div>`
   }]
   // tslint:enable:max-line-length
 


### PR DESCRIPTION
It all started when I started getting:

```
2020-08-21 03:15:31.939 eqMac[91595:332539] Sentry Started -- Version: 4.5.0
eqMac (Source/Application.swift:184) Setting up Audio Engine
Error: 2003332927 ->  /Users/romanskisils/Programming/Bitgapp/eqmac/native/app/Source/Audio/Sources/System/Driver.swift:123

ERROR: SentryCrashMachineContext.c (232): void sentrycrashmc_resumeEnvironment(): thread_resume (0000ec07): (os/kern) object terminated
[1]    91595 segmentation fault  ./eqMac
```

After I manually removed all the files and redownloaded the app the problem continued, so I tried running the uninstall command but it wasn't successfully restarting`com.apple.audio.coreaudiod`. After I took the `&>/dev/null` off the end I noticed that I was getting an error message:

```
Could not kickstart service "com.apple.audio.coreaudiod": 1: Operation not permitted
```

After inserting `sudo` between the `&&` and `launchctl` it worked successfully and I was able to reinstall the driver and get eqMac working again.