### PR TITLE
Fixed popover show/hide calls to get rid of blinks

### DIFF
--- a/native/app/Source/UI/Popover.swift
+++ b/native/app/Source/UI/Popover.swift
@@ -80,12 +80,13 @@ class Popover: NSObject, NSPopoverDelegate {
     }
     
     func show() {
-        popover.show(relativeTo: NSZeroRect, of: statusItem.button, preferredEdge: .minY)
         NSApp.activate(ignoringOtherApps: true)
+        popover.show(relativeTo: NSZeroRect, of: statusItem.button, preferredEdge: .minY)
         popover.becomeFirstResponder()
     }
     
     func hide() {
+        popover.resignFirstResponder()
         popover.close()
         statusItem.highlighted = false
     }


### PR DESCRIPTION
Found that #403 issue caused by not correct chains of calls for popover show and hide. 
Fixed it to get rid of blinks.
https://youtu.be/aGWUrJaYQR0