### PR TITLE
Fix for output change crashes

### DIFF
--- a/native/app/Source/Application.swift
+++ b/native/app/Source/Application.swift
@@ -242,7 +242,8 @@ class Application {
   
   private static var ignoreNextDriverMuteEvent = false
   private static func setupDriverDeviceEvents () {
-    AudioDeviceEvents.on(.volumeChanged, onDevice: Driver.device!) {
+    guard let driverDevice = Driver.device else { return }
+    AudioDeviceEvents.on(.volumeChanged, onDevice: driverDevice) {
       if ignoreNextVolumeEvent {
         ignoreNextVolumeEvent = false
         return
@@ -250,14 +251,13 @@ class Application {
       if (overrideNextVolumeEvent) {
         overrideNextVolumeEvent = false
         ignoreNextVolumeEvent = true
-        Driver.device!.setVirtualMasterVolume(1, direction: .playback)
+        driverDevice.setVirtualMasterVolume(1, direction: .playback)
         return
       }
-      let gain = Double(Driver.device!.virtualMasterVolume(direction: .playback)!)
+      let gain = Double(driverDevice.virtualMasterVolume(direction: .playback)!)
       if (gain <= 1 && gain != Application.store.state.effects.volume.gain) {
         Application.dispatchAction(VolumeAction.setGain(gain, false))
       }
-      
     }
     
     AudioDeviceEvents.on(.muteChanged, onDevice: Driver.device!) {
@@ -265,7 +265,7 @@ class Application {
         ignoreNextDriverMuteEvent = false
         return
       }
-      Application.dispatchAction(VolumeAction.setMuted(Driver.device!.mute))
+      Application.dispatchAction(VolumeAction.setMuted(driverDevice.mute))
     }
   }
   

--- a/native/app/Source/Audio/Volume/Volume.swift
+++ b/native/app/Source/Audio/Volume/Volume.swift
@@ -77,19 +77,25 @@ class Volume: StoreSubscriber {
           }
         }
         
-        Driver.device!.setVirtualMasterVolume(Float32(gain), direction: .playback)
+        if let driverDevice = Driver.device {
+            driverDevice.setVirtualMasterVolume(Float32(gain), direction: .playback)
+        }
       }
       
       leftGain = newLeftGain
       rightGain = newRightGain
       
       if (!volumeSupported) {
-        Driver.device!.mute = false
+        if let driverDevice = Driver.device {
+          driverDevice.mute = false
+        }
         device.mute = false
       }
       
       let shouldMute = gain == 0.0
-      Driver.device!.mute = shouldMute
+      if let driverDevice = Driver.device {
+        driverDevice.mute = shouldMute
+      }
       device.mute = shouldMute
       
       


### PR DESCRIPTION
Fixed couple of crashes related to force unwrap of optional Driver.device when output chages like on/off bluetooth headphones in native part.

Crash 1:
![crash 1 - Volume swift](https://user-images.githubusercontent.com/1412213/97775341-3dfe4980-1b79-11eb-8e83-97178a135874.jpg)

Crash 2:
![crash 2 - Application swift 2020-10-31 12-10-42](https://user-images.githubusercontent.com/1412213/97775343-46568480-1b79-11eb-81ca-09220710011d.jpg)
