### PR TITLE
Fix popover remaining open after switching macOS Spaces

### DIFF
--- a/native/app/Source/AppDelegate.swift
+++ b/native/app/Source/AppDelegate.swift
@@ -59,6 +59,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SUUpdaterDelegate {
     NSWorkspace.shared.notificationCenter.addObserver(
         self, selector: #selector(willSleep(event:)),
         name: NSWorkspace.willSleepNotification, object: nil)
+
+    NSWorkspace.shared.notificationCenter.addObserver(
+        self, selector: #selector(activeSpaceDidChange(event:)),
+        name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
   }
   
   func applicationWillTerminate(_ aNotification: Notification) {
@@ -129,6 +133,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SUUpdaterDelegate {
   @objc func didWakeUp(event: NSNotification) {
     Application.handleWakeUp()
   }
+
+  @objc func activeSpaceDidChange(event: NSNotification) {
+    if UI.hasLoaded && UI.mode == .popover {
+      UI.close()
+    }
+  }
 }
-
-


### PR DESCRIPTION
## Summary
Fixes the eqMac menu bar popover getting stuck on another macOS Space after the user switches desktops.

When the active Space changes, eqMac now closes the popover window if the UI is running in popover mode. This lets the next menu bar icon click reopen the popover in the current Space, matching expected menu bar popover behavior.

Fixes #1021

## Testing
- Ran `xcrun swiftc -parse native/app/Source/AppDelegate.swift`
- Typechecked `NSWorkspace.activeSpaceDidChangeNotification`
- Confirmed the Xcode workspace resolves with `xcodebuild -list -workspace native/eqMac.xcworkspace`

Full native build was blocked locally because `pod install` could not clone `https://github.com/bitgapp/AMCoreAudio.git` (`Repository not found`).